### PR TITLE
JUCX: fix test for cuda buffers.

### DIFF
--- a/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
+++ b/bindings/java/src/test/java/org/openucx/jucx/UcpEndpointTest.java
@@ -57,7 +57,7 @@ public class UcpEndpointTest extends UcxTest {
     public void testGetNB(int memType) throws Exception {
         System.out.println("Running testGetNB with memType: " + memType);
         // Crerate 2 contexts + 2 workers
-        UcpParams params = new UcpParams().requestRmaFeature();
+        UcpParams params = new UcpParams().requestRmaFeature().requestTagFeature();
         UcpWorkerParams rdmaWorkerParams = new UcpWorkerParams().requestWakeupRMA();
         UcpContext context1 = new UcpContext(params);
         UcpContext context2 = new UcpContext(params);
@@ -119,7 +119,7 @@ public class UcpEndpointTest extends UcxTest {
     public void testPutNB(int memType) throws Exception {
         System.out.println("Running testPutNB with memType: " + memType);
         // Crerate 2 contexts + 2 workers
-        UcpParams params = new UcpParams().requestRmaFeature();
+        UcpParams params = new UcpParams().requestRmaFeature().requestTagFeature();
         UcpWorkerParams rdmaWorkerParams = new UcpWorkerParams().requestWakeupRMA();
         UcpContext context1 = new UcpContext(params);
         UcpContext context2 = new UcpContext(params);


### PR DESCRIPTION
## What
Fixes JUCX tests with real cuda buffers, except of IOV test.

@Akshay-Venkatesh does iov send recv supported with cuda memory? If no, I'll remove it from jucx tests.

https://github.com/openucx/ucx/pull/6778